### PR TITLE
fix: Keep player controls visible when paused

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1022,9 +1022,13 @@ class PlPlayerController {
             }
           }
           playerStatus.value = PlayerStatus.playing;
+          if (showControls.value) {
+            hideTaskControls();
+          }
         } else {
           disableAutoEnterPip();
           playerStatus.value = PlayerStatus.paused;
+          controls = true;
         }
         videoPlayerServiceHandler?.onStatusChange(
           playerStatus.value,
@@ -1296,7 +1300,9 @@ class PlPlayerController {
   void hideTaskControls() {
     _timer?.cancel();
     _timer = Timer(showControlDuration, () {
-      if (!isSliderMoving.value && !tripling) {
+      if (!isSliderMoving.value &&
+          !tripling &&
+          playerStatus.value != PlayerStatus.paused) {
         controls = false;
       }
       _timer = null;
@@ -1416,7 +1422,7 @@ class PlPlayerController {
   set controls(bool visible) {
     showControls.value = visible;
     _timer?.cancel();
-    if (visible) {
+    if (visible && playerStatus.value != PlayerStatus.paused) {
       hideTaskControls();
     }
   }
@@ -1459,6 +1465,7 @@ class PlPlayerController {
 
   // 双击播放、暂停
   Future<void> onDoubleTapCenter() async {
+    controls = true;
     if (!isLive && _isCompleted) {
       await videoPlayerController!.seek(Duration.zero);
       videoPlayerController!.play();

--- a/lib/plugin/pl_player/view.dart
+++ b/lib/plugin/pl_player/view.dart
@@ -1186,7 +1186,9 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
         break;
       default:
         if (_suspendedDm == null) {
-          plPlayerController.controls = !plPlayerController.showControls.value;
+          if (plPlayerController.playerStatus.value != PlayerStatus.paused) {
+            plPlayerController.controls = !plPlayerController.showControls.value;
+          }
         } else if (_suspendedDm!.suspend) {
           _dmOffset.value = details.localPosition;
         } else {


### PR DESCRIPTION
Modified the video player controller to prevent the controls from auto-hiding when playback is paused. This improves usability on remote-controlled devices like Android TV where persistent on-screen controls are necessary for navigation.

Key changes:
- When the player state changes to paused, the controls are now explicitly made visible.
- The auto-hide timer logic in `hideTaskControls` now checks if the player is paused before hiding the controls.
- The `controls` setter only starts the auto-hide timer if the video is actively playing.
- Tapping the screen no longer hides the controls when the video is paused.